### PR TITLE
Add Omarchy customization system with Hyprland overrides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,102 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Overview
+
+This is a dotfiles repository that automates the setup of Linux (primarily Fedora) and macOS development environments. It uses a modular service-based architecture where each application or component is configured through self-contained service directories.
+
+## Installation Commands
+
+### Linux (Fedora)
+```bash
+# Install everything
+bash install.sh
+
+# Install specific service(s)
+bash install.sh services/shell services/neovim
+```
+
+### macOS
+```bash
+bash install-macos.sh
+```
+
+## Architecture
+
+### Service-Based Structure
+
+Each service lives in `services/[service-name]/` and contains:
+- `install.sh` - Installation script for that service
+- Configuration files and directories for the service
+
+### Installation Flow
+
+1. **install.sh** (main installer):
+   - Must NOT be run as root
+   - First installs base services: `base` and `shell` (in that order)
+   - Then installs all other services in `services/` directory
+   - Can accept specific service paths as arguments for selective installation
+   - Changes to service directory before running its install.sh
+
+2. **Base Services**:
+   - `services/base/install.sh`: Sets up RPM Fusion repos, extends LVM partition, installs core utilities (curl, git, htop, etc.)
+   - `services/shell/install.sh`: Installs fish shell, starship prompt, and shell configurations
+
+3. **Service Install Scripts**:
+   - Run from within their own directory (install.sh changes to service_dir before executing)
+   - Use `$SCRIPT_DIR` to reference their own files
+   - Use `rsync -r --delete` for config file synchronization
+   - Install to standard XDG paths: `~/.config/`, `~/.local/bin/`, etc.
+
+### Common Patterns
+
+**Package Installation**:
+```bash
+sudo dnf install -y [packages]  # Fedora/Linux
+brew install [packages]          # macOS
+```
+
+**Config File Management**:
+```bash
+# Remove and sync entire directory
+rm -rf $HOME/.config/[app]
+rsync -r --delete $SCRIPT_DIR/[config]/ $HOME/.config/[app]/
+
+# Copy single file
+cp $SCRIPT_DIR/[file] $HOME/.config/[file]
+```
+
+**Script Directory Resolution**:
+```bash
+# Linux services
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
+# macOS script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+```
+
+## Key Services
+
+- **sway**: Wayland compositor with waybar, mako, rofi configs. Uses custom wrapper for session management
+- **neovim**: LazyVim-based setup with custom plugins in `lua/plugins/`
+- **ghostty**: Terminal emulator configuration
+- **desktop**: Enables GDM and graphical.target for desktop environments
+- **1password**, **github**, **git**: Authentication and development tools
+- **docker**, **flatpak**: Container and package management
+
+## Testing Changes
+
+When modifying service install scripts:
+1. Test the specific service: `bash install.sh services/[service-name]`
+2. Verify it works from any directory (script uses absolute paths)
+3. Check that config files are properly synced to home directory
+4. For destructive changes, test in VM or on non-production system
+
+## Important Notes
+
+- All service install.sh scripts are run from their own directory by the main installer
+- Use `rsync -r --delete` for config sync to ensure clean state
+- macOS installation is a single monolithic script (install-macos.sh)
+- The repository should be cloned to `$HOME/code/github/dotfiles` for consistency
+- hatti.cfg is a game configuration file (ezQuake) and unrelated to system setup

--- a/install-omarchy.sh
+++ b/install-omarchy.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+OMARCHY_DIR="$SCRIPT_DIR/omarchy"
+
+if [ "$EUID" -eq 0 ]; then
+  echo "Do not run as root"
+  exit 1
+fi
+
+# Install an omarchy module
+install_module() {
+  local module_dir="$1"
+
+  if [ -f "$module_dir/install.sh" ]; then
+    echo "Installing $(basename $module_dir)..."
+    cd "$module_dir"
+    bash install.sh
+    cd - >/dev/null
+  fi
+}
+
+# Main installation
+main() {
+  echo "Starting Omarchy customization setup..."
+
+  if [ $# -eq 0 ]; then
+    echo "Installing all Omarchy customizations..."
+
+    for module in $(ls -1 "$OMARCHY_DIR"); do
+      if [ -d "$OMARCHY_DIR/$module" ]; then
+        install_module "$OMARCHY_DIR/$module"
+      fi
+    done
+  else
+    echo "Installing requested module: $1"
+    install_module "$1"
+  fi
+
+  echo ""
+  echo "Omarchy customizations installed successfully!"
+  echo ""
+  echo "Note: You may need to reload Hyprland for changes to take effect:"
+  echo "  Press Super+Esc -> Relaunch"
+}
+
+main "$@"

--- a/omarchy/hypr/bindings.conf
+++ b/omarchy/hypr/bindings.conf
@@ -1,0 +1,7 @@
+$terminal = uwsm app -- $TERMINAL
+$browser = omarchy-launch-browser
+
+bindd = SUPER, return, Terminal, exec, $terminal --working-directory="$(omarchy-cmd-terminal-cwd)"
+bindd = SUPER, F, File manager, exec, uwsm app -- nautilus --new-window
+bindd = SUPER, B, Browser, exec, $browser
+

--- a/omarchy/hypr/hypridle.conf
+++ b/omarchy/hypr/hypridle.conf
@@ -1,0 +1,22 @@
+general {
+    lock_cmd = omarchy-lock-screen                         # lock screen and 1password
+    before_sleep_cmd = loginctl lock-session               # lock before suspend.
+    after_sleep_cmd = hyprctl dispatch dpms on             # to avoid having to press a key twice to turn on the display.
+    inhibit_sleep = 3                                      # wait until screen is locked
+}
+
+listener {
+    timeout = 150                                             # 2.5min
+    on-timeout = pidof hyprlock || omarchy-launch-screensaver # start screensaver (if we haven't locked already)
+}
+
+listener {
+    timeout = 300                      # 5min
+    on-timeout = loginctl lock-session # lock screen when timeout has passed
+}
+
+listener {
+    timeout = 330                                            # 5.5min
+    on-timeout = hyprctl dispatch dpms off                   # screen off when timeout has passed
+    on-resume = hyprctl dispatch dpms on && brightnessctl -r # screen on when activity is detected
+}

--- a/omarchy/hypr/input.conf
+++ b/omarchy/hypr/input.conf
@@ -1,0 +1,19 @@
+input {
+  kb_layout = se
+  kb_options = compose:caps
+
+  repeat_rate = 40
+  repeat_delay = 250
+
+  sensitivity = 0.45
+  natural_scroll = true
+
+  touchpad {
+    natural_scroll = true
+    scroll_factor = 0.4
+  }
+}
+
+windowrule = scrolltouchpad 1.5, class:(Alacritty|kitty)
+windowrule = scrolltouchpad 0.2, class:com.mitchellh.ghostty
+

--- a/omarchy/hypr/install.sh
+++ b/omarchy/hypr/install.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
+mkdir -p $HOME/.config/hypr
+
+echo "Installing Hyprland configuration overrides..."
+
+for config_file in "$SCRIPT_DIR"/*.conf; do
+  if [ -f "$config_file" ]; then
+    filename=$(basename "$config_file")
+    echo "  Installing $filename"
+    cp "$config_file" "$HOME/.config/hypr/$filename"
+  fi
+done
+
+echo "Hyprland customizations installed!"

--- a/omarchy/hypr/monitors.conf
+++ b/omarchy/hypr/monitors.conf
@@ -1,0 +1,2 @@
+env = GDK_SCALE,1
+monitor=,preferred,auto,1


### PR DESCRIPTION
## Summary
- Added modular Omarchy customization system following the same pattern as Fedora services
- Created `install-omarchy.sh` main installer that calls module install scripts
- Added `omarchy/hypr/` module with Hyprland configuration overrides (input, monitors, bindings, hypridle)
- Created `CLAUDE.md` documentation for future Claude Code instances

## Test plan
- [ ] Run `bash install-omarchy.sh` to install all Omarchy customizations
- [ ] Verify Hyprland configs are copied to `~/.config/hypr/`
- [ ] Test individual module installation: `bash install-omarchy.sh omarchy/hypr`

🤖 Generated with [Claude Code](https://claude.com/claude-code)